### PR TITLE
timestamp for files in dir of extract zip correction - fix

### DIFF
--- a/korlibs-io/module.yaml
+++ b/korlibs-io/module.yaml
@@ -24,7 +24,7 @@ dependencies:
   - com.soywiz:korlibs-platform:6.0.0: exported
   - com.soywiz:korlibs-datastructure:6.0.0: exported
   - com.soywiz:korlibs-number:6.0.0: exported
-  - com.soywiz:korlibs-time-core:6.0.0: exported
+  - com.soywiz:korlibs-time:6.0.0: exported
   - com.soywiz:korlibs-logger:6.0.0: exported
   - com.soywiz:korlibs-dyn:6.0.0: exported
   - com.soywiz:korlibs-string:6.0.0: exported

--- a/korlibs-io/src/korlibs/io/compression/zip/ZipBuilder.kt
+++ b/korlibs-io/src/korlibs/io/compression/zip/ZipBuilder.kt
@@ -7,6 +7,7 @@ import korlibs.io.lang.*
 import korlibs.io.stream.*
 import korlibs.io.util.checksum.*
 import korlibs.memory.*
+import korlibs.time.DateTimeTz
 
 class ZipBuilder {
     companion object {
@@ -25,6 +26,24 @@ class ZipBuilder {
                 createZipFromTreeTo(folder, this, compression, useFolderAsRoot)
             }
             return zipFile
+        }
+
+        private fun dosDate(dt: DateTimeTz): Int {
+            val year = dt.yearInt - 1980
+            val month = dt.month1
+            val day = dt.dayOfMonth
+            return (day and 0x1F) or
+                    ((month and 0x0F) shl 5) or
+                    ((year and 0x7F) shl 9)
+        }
+
+        private fun dosTime(dt: DateTimeTz): Int {
+            val hour = dt.hours
+            val minute = dt.minutes
+            val second = dt.seconds / 2
+            return (second and 0x1F) or
+                    ((minute and 0x3F) shl 5) or
+                    ((hour and 0x1F) shl 11)
         }
 
         suspend fun createZipFromTreeTo(
@@ -70,8 +89,9 @@ class ZipBuilder {
             val flags = 2048
             val compressionMethod = compression.zipId
             val compressed = compressionMethod != 0
-            val date = 0
-            val time = 0
+            val dt = DateTimeTz.nowLocal()
+            val date = dosDate(dt)
+            val time = dosTime(dt)
             //var crc32 = if (compressed) 0 else entry.checksum(CRC32)
             var crc32 = entry.checksum(CRC32)
             val name = entry.fullName.trim('/')
@@ -90,8 +110,8 @@ class ZipBuilder {
                 write16LE(extractVersion)
                 write16LE(flags)
                 write16LE(compressionMethod)
-                write16LE(date)
                 write16LE(time)
+                write16LE(date)
                 write32LE(crc32)
                 write32LE(compressedSize)
                 write32LE(uncompressedSize)

--- a/korlibs-io/test@jvm/korlibs/io/compression/zip/ZipBuilderTest.kt
+++ b/korlibs-io/test@jvm/korlibs/io/compression/zip/ZipBuilderTest.kt
@@ -6,6 +6,7 @@ import korlibs.io.compression.deflate.*
 import korlibs.io.compression.lzma.*
 import korlibs.io.file.*
 import korlibs.io.file.std.*
+import java.io.File
 import kotlin.test.*
 
 class ZipBuilderTest {
@@ -47,4 +48,18 @@ class ZipBuilderTest {
         )
 
     }
+
+    @Test
+    fun testZip() = suspendTest {
+        val vfs = MemoryVfs()
+        val indexFile = vfs["textFileTest.txt"]
+        indexFile.writeString("TestCode")
+        val mediaFolder = vfs["subfolder"]
+        mediaFolder.mkdir()
+        mediaFolder["test.txt"].writeString("TestCode")
+        val bytes = vfs.createZipFromTree()
+        val file = File("zipTest.zip")
+        file.writeBytes(bytes)
+    }
+    
 }


### PR DESCRIPTION
When extracting a zip file created, the files have incorrect timestamp. 
![image](https://github.com/user-attachments/assets/def29ff4-fe79-41e6-9ac2-b8ee888db1d2)

Changed the following
 -> order of date and time bits writing in file headers
 -> used DateTimeTz class to get localtime (Imported korlibs-time and removed time-core in dependencies)
 -> added apis to construct ms dos date and ms dos time 
 
 
 Please check these changes and let me know if I have missed any usecases
